### PR TITLE
Dependency issue for ssh

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -5,11 +5,7 @@
 		"./..."
 	],
 	"Deps": [
-		{
-			"ImportPath": "code.google.com/p/go.crypto/ssh",
-			"Comment": "null-236",
-			"Rev": "69e2a90ed92d03812364aeb947b7068dc42e561e"
-		},
+		
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws",
 			"Comment": "v0.9.14-3-g308eaa6",

--- a/utils/key_helper.go
+++ b/utils/key_helper.go
@@ -3,8 +3,7 @@ package utils
 import (
 	"encoding/pem"
 	"strings"
-
-	ssh "code.google.com/p/go.crypto/ssh"
+	ssh "golang.org/x/crypto/ssh"
 	rsa "crypto/rsa"
 )
 

--- a/utils/ssh_client.go
+++ b/utils/ssh_client.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"code.google.com/p/go.crypto/ssh"
+	ssh "golang.org/x/crypto/ssh"
 )
 
 type SshClient interface {


### PR DESCRIPTION
While running the godep restore command, its producing issue for the url given for the ssh.
Also once we removed the dependency from godep file, while building the application , same issue is reproducible because of the **code.google.com/p/go.crypto/ssh** link, which is not working.
